### PR TITLE
Fix handling of fuels with container items

### DIFF
--- a/src/main/java/shadows/fastfurnace/block/TileFastFurnace.java
+++ b/src/main/java/shadows/fastfurnace/block/TileFastFurnace.java
@@ -88,8 +88,9 @@ public class TileFastFurnace extends TileEntityFurnace {
 	protected void burnFuel(ItemStack fuel, boolean burnedThisTick) {
 		currentItemBurnTime = (furnaceBurnTime = getItemBurnTime(fuel));
 		if (this.isBurning()) {
+			Item item = fuel.getItem();
 			fuel.shrink(1);
-			if (fuel.isEmpty()) furnaceItemStacks.set(FUEL, fuel.getItem().getContainerItem(fuel));
+			if (fuel.isEmpty()) furnaceItemStacks.set(FUEL, item.getContainerItem(fuel));
 			if (!burnedThisTick) world.setBlockState(pos, Blocks.LIT_FURNACE.getDefaultState().withProperty(BlockFurnace.FACING, world.getBlockState(pos).getValue(BlockFurnace.FACING)));
 		}
 	}


### PR DESCRIPTION
Once the itemstack was shrunk to 0 the item became air, so buckets got voided.