### PR TITLE
Fixed coremod transformers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 
-version = '2.2.0'
+version = '2.2.1'
 group = 'shadows.fastfurnace'
 archivesBaseName = 'FastFurnace-1.14.4'
 

--- a/src/main/resources/javascript/burn-time.js
+++ b/src/main/resources/javascript/burn-time.js
@@ -19,6 +19,7 @@ function initializeCoreMod() {
                 var Opcodes = Java.type('org.objectweb.asm.Opcodes');
                 var VarInsnNode = Java.type('org.objectweb.asm.tree.VarInsnNode');
                 var InsnList = Java.type('org.objectweb.asm.tree.InsnList');
+                var InsnNode = Java.type('org.objectweb.asm.tree.InsnNode');
 
                 var insn = new InsnList();
                 insn.add(new VarInsnNode(Opcodes.ALOAD, 1));

--- a/src/main/resources/javascript/is-fuel.js
+++ b/src/main/resources/javascript/is-fuel.js
@@ -19,9 +19,10 @@ function initializeCoreMod() {
                 var Opcodes = Java.type('org.objectweb.asm.Opcodes');
                 var VarInsnNode = Java.type('org.objectweb.asm.tree.VarInsnNode');
                 var InsnList = Java.type('org.objectweb.asm.tree.InsnList');
+                var InsnNode = Java.type('org.objectweb.asm.tree.InsnNode');
 
                 var insn = new InsnList();
-                insn.add(new VarInsnNode(Opcodes.ALOAD, 1));
+                insn.add(new VarInsnNode(Opcodes.ALOAD, 0));
                 insn.add(ASMAPI.buildMethodCall(
                     owner,
                     name,


### PR DESCRIPTION
- Added missing declaration for 'InsnNode' in both burn-time and is-fuel
  transformers that prevented them from being applied.
- Fixed ALOAD targetting non-existent local var in is-fuel.
- Bumped patch version.
